### PR TITLE
Verifier: Mark orphaned DICompileUnits as a debug info failure.

### DIFF
--- a/lib/IR/Verifier.cpp
+++ b/lib/IR/Verifier.cpp
@@ -2035,9 +2035,9 @@ void Verifier::visitFunction(const Function &F) {
         continue;
 
       // FIXME: Once N is canonical, check "SP == &N".
-      Assert(SP->describes(&F),
-             "!dbg attachment points at wrong subprogram for function", N, &F,
-             &I, DL, Scope, SP);
+      AssertDI(SP->describes(&F),
+               "!dbg attachment points at wrong subprogram for function", N, &F,
+               &I, DL, Scope, SP);
     }
 }
 
@@ -4205,10 +4205,10 @@ void Verifier::visitDbgIntrinsic(StringRef Kind, DbgIntrinsicTy &DII) {
   if (!VarSP || !LocSP)
     return; // Broken scope chains are checked elsewhere.
 
-  Assert(VarSP == LocSP, "mismatched subprogram between llvm.dbg." + Kind +
-                             " variable and !dbg attachment",
-         &DII, BB, F, Var, Var->getScope()->getSubprogram(), Loc,
-         Loc->getScope()->getSubprogram());
+  AssertDI(VarSP == LocSP, "mismatched subprogram between llvm.dbg." + Kind +
+                               " variable and !dbg attachment",
+           &DII, BB, F, Var, Var->getScope()->getSubprogram(), Loc,
+           Loc->getScope()->getSubprogram());
 }
 
 static uint64_t getVariableSize(const DILocalVariable &V) {
@@ -4271,9 +4271,9 @@ void Verifier::verifyBitPieceExpression(const DbgInfoIntrinsic &I) {
 
   unsigned PieceSize = E->getBitPieceSize();
   unsigned PieceOffset = E->getBitPieceOffset();
-  Assert(PieceSize + PieceOffset <= VarSize,
+  AssertDI(PieceSize + PieceOffset <= VarSize,
          "piece is larger than or outside of variable", &I, V, E);
-  Assert(PieceSize != VarSize, "piece covers entire variable", &I, V, E);
+  AssertDI(PieceSize != VarSize, "piece covers entire variable", &I, V, E);
 }
 
 void Verifier::verifyCompileUnits() {
@@ -4281,7 +4281,7 @@ void Verifier::verifyCompileUnits() {
   SmallPtrSet<const Metadata *, 2> Listed;
   if (CUs)
     Listed.insert(CUs->op_begin(), CUs->op_end());
-  Assert(
+  AssertDI(
       std::all_of(CUVisited.begin(), CUVisited.end(),
                   [&Listed](const Metadata *CU) { return Listed.count(CU); }),
       "All DICompileUnits must be listed in llvm.dbg.cu");

--- a/unittests/IR/VerifierTest.cpp
+++ b/unittests/IR/VerifierTest.cpp
@@ -14,6 +14,7 @@
 #include "llvm/IR/GlobalAlias.h"
 #include "llvm/IR/GlobalVariable.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/LegacyPassManager.h"
 #include "llvm/IR/Module.h"
@@ -146,26 +147,58 @@ TEST(VerifierTest, CrossModuleMetadataRef) {
 }
 
 TEST(VerifierTest, StripInvalidDebugInfo) {
-  LLVMContext C;
-  Module M("M", C);
-  DIBuilder DIB(M);
-  DIB.createCompileUnit(dwarf::DW_LANG_C89, "broken.c", "/",
-                        "unittest", false, "", 0);
-  DIB.finalize();
-  EXPECT_FALSE(verifyModule(M));
+  {
+    LLVMContext C;
+    Module M("M", C);
+    DIBuilder DIB(M);
+    DIB.createCompileUnit(dwarf::DW_LANG_C89, "broken.c", "/", "unittest",
+                          false, "", 0);
+    DIB.finalize();
+    EXPECT_FALSE(verifyModule(M));
 
-  // Now break it.
-  auto *File = DIB.createFile("not-a-CU.f", ".");
-  NamedMDNode *NMD = M.getOrInsertNamedMetadata("llvm.dbg.cu");
-  NMD->addOperand(File);
-  EXPECT_TRUE(verifyModule(M));
+    // Now break it by inserting non-CU node to the list of CUs.
+    auto *File = DIB.createFile("not-a-CU.f", ".");
+    NamedMDNode *NMD = M.getOrInsertNamedMetadata("llvm.dbg.cu");
+    NMD->addOperand(File);
+    EXPECT_TRUE(verifyModule(M));
 
-  ModulePassManager MPM(true);
-  MPM.addPass(VerifierPass(false));
-  ModuleAnalysisManager MAM(true);
-  MAM.registerPass(VerifierAnalysis());
-  MPM.run(M, &MAM);
-  EXPECT_FALSE(verifyModule(M));
+    ModulePassManager MPM(true);
+    MPM.addPass(VerifierPass(false));
+    ModuleAnalysisManager MAM(true);
+    MAM.registerPass(VerifierAnalysis());
+    MPM.run(M, &MAM);
+    EXPECT_FALSE(verifyModule(M));
+  }
+  {
+    LLVMContext C;
+    Module M("M", C);
+    DIBuilder DIB(M);
+    auto *CU = DIB.createCompileUnit(dwarf::DW_LANG_C89, "broken.c", "/",
+                                     "unittest", false, "", 0);
+    new GlobalVariable(M, Type::getInt8Ty(C), false,
+                       GlobalValue::ExternalLinkage, nullptr, "g");
+
+    auto *F = cast<Function>(M.getOrInsertFunction(
+        "f", FunctionType::get(Type::getVoidTy(C), false)));
+    IRBuilder<> Builder(BasicBlock::Create(C, "", F));
+    Builder.CreateUnreachable();
+    F->setSubprogram(DIB.createFunction(CU, "f", "f",
+                                        DIB.createFile("broken.c", "/"), 1,
+                                        nullptr, true, true, 1));
+    DIB.finalize();
+    EXPECT_FALSE(verifyModule(M));
+
+    // Now break it by not listing the CU at all.
+    M.eraseNamedMetadata(M.getOrInsertNamedMetadata("llvm.dbg.cu"));
+    EXPECT_TRUE(verifyModule(M));
+
+    ModulePassManager MPM(true);
+    MPM.addPass(VerifierPass(false));
+    ModuleAnalysisManager MAM(true);
+    MAM.registerPass(VerifierAnalysis());
+    MPM.run(M, &MAM);
+    EXPECT_FALSE(verifyModule(M));
+  }
 }
 
 


### PR DESCRIPTION
This is a follow-up to r268778 that adds a couple of missing cases,
most notably orphaned compile units.

rdar://problem/28193346

git-svn-id: https://llvm.org/svn/llvm-project/llvm/trunk@281508 91177308-0d34-0410-b5e6-96231b3b80d8
(cherry picked from commit 50aa9109c611755c1f00ed958292b67dc95c358e)
